### PR TITLE
Issue #2 - MustLoadTemplate utility function

### DIFF
--- a/util.go
+++ b/util.go
@@ -11,6 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+func MustLoadTemplate(pathToTemplate string) string {
+	contents, err := LoadTemplate(pathToTemplate)
+	if err != nil {
+		panic(err)
+	}
+	return contents
+}
 func LoadTemplate(pathToTemplate string) (string, error) {
 
 	b, err := ioutil.ReadFile(pathToTemplate)


### PR DESCRIPTION
Adds MustLoadTemplate utility function to address issue #2. MustLoadTemplate will panic if an error occured while loading the requested template.﻿
